### PR TITLE
[#4] Mentions are on a separate line from the message

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,6 @@ def dot_ack(message, replier):
     if 1 == len(message.full_text):
         logging.info('received dotpost "' + message.full_text + '" from ~' + message.author)
         logging.info('sending "' + messageAck + '" to ~' + message.author)
-        replier({"mention": "~" + message.author})
-        replier({"text": messageAck})
+        replier({"mention": "~" + message.author}, {"text": messageAck})
 
 urbitClient.listen(dot_ack)


### PR DESCRIPTION
Previously, we sent the @p mention of a user and the ACK text in separate messages. Now, we'll send it in a single line single message. This resolves #4 . 

Compare ~dozzod^sorwet & the Dot Bot in the screenshot below - ~dozzod^sorwet is the intended functionality.

![image](https://user-images.githubusercontent.com/80287270/115476427-7537e400-a207-11eb-9668-fafdd83e4f3a.png)
